### PR TITLE
add additional installation tips for bitnami

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ helm upgrade --install alidns-webhook alidns-webhook \
     --repo https://wjiec.github.io/alidns-webhook \
     --namespace cert-manager --create-namespace \
     --set groupName=acme.yourcompany.com
+
+# Note: If you installed cert-manager via bitnami charts, you need to add the additional
+#   `--set certManager.serviceAccountName=cert-manager-controller`
+# parameter to specify the ServiceAccount to use.
 ```
 
 It will install the alidns-webhook in the cert-manager namespace, creating that namespace if it doesn't already exist.


### PR DESCRIPTION
The default serviceaccount for cert-manager installed via bitnami charts is `cert-manager-controller`, which is different from the official `cert-manager`.