### PR TITLE
Fix invalid zone detection by resolving zone via AliDNS

### DIFF
--- a/.github/workflows/k8s-compatible.yml
+++ b/.github/workflows/k8s-compatible.yml
@@ -11,11 +11,11 @@ jobs:
     strategy:
       matrix:
         node-image:
-          - kindest/node:v1.30.13@sha256:397209b3d947d154f6641f2d0ce8d473732bd91c87d9575ade99049aa33cd648
-          - kindest/node:v1.31.12@sha256:0f5cc49c5e73c0c2bb6e2df56e7df189240d83cf94edfa30946482eb08ec57d2
-          - kindest/node:v1.32.8@sha256:abd489f042d2b644e2d033f5c2d900bc707798d075e8186cb65e3f1367a9d5a1
-          - kindest/node:v1.33.4@sha256:25a6018e48dfcaee478f4a59af81157a437f15e6e140bf103f85a2e7cd0cbbf2
-          - kindest/node:v1.34.0@sha256:7416a61b42b1662ca6ca89f02028ac133a309a2a30ba309614e8ec94d976dc5a
+          - kindest/node:v1.31.14@sha256:6f86cf509dbb42767b6e79debc3f2c32e4ee01386f0489b3b2be24b0a55aac2b
+          - kindest/node:v1.32.11@sha256:5fc52d52a7b9574015299724bd68f183702956aa4a2116ae75a63cb574b35af8
+          - kindest/node:v1.33.7@sha256:d26ef333bdb2cbe9862a0f7c3803ecc7b4303d8cea8e814b481b09949d353040
+          - kindest/node:v1.34.3@sha256:08497ee19eace7b4b5348db5c6a1591d7752b164530a36f855cb0f2bdcbadd48
+          - kindest/node:v1.35.0@sha256:452d707d4862f52530247495d180205e029056831160e22870e37e3f6c1ac31f
     runs-on: ubuntu-latest
 
     steps:

--- a/alidns.go
+++ b/alidns.go
@@ -5,6 +5,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"strings"
 
 	alidns "github.com/alibabacloud-go/alidns-20150109/v4/client"
 	openapi "github.com/alibabacloud-go/darabonba-openapi/v2/client"
@@ -55,8 +56,8 @@ func (s *AliSolver) Present(challenge *acme.ChallengeRequest) error {
 		return err
 	}
 
-	err = dns.AddRecord(challenge.ResolvedFQDN, challenge.ResolvedZone, challenge.Key)
-	if err != nil {
+	fqdn, zone := s.resolveChallengeDNSNames(s.ctx, challenge)
+	if err = dns.AddRecord(fqdn, zone, challenge.Key); err != nil {
 		klog.Errorf("Failed to add TXT record for %q cause by %q",
 			challenge.ResolvedFQDN, err.Error())
 	}
@@ -79,8 +80,8 @@ func (s *AliSolver) CleanUp(challenge *acme.ChallengeRequest) error {
 		return err
 	}
 
-	err = dns.DeleteRecord(challenge.ResolvedFQDN, challenge.ResolvedZone)
-	if err != nil {
+	fqdn, zone := s.resolveChallengeDNSNames(s.ctx, challenge)
+	if err = dns.DeleteRecord(fqdn, zone); err != nil {
 		klog.Errorf("Failed to delete TXT record for %q cause by %q",
 			challenge.ResolvedFQDN, err.Error())
 	}
@@ -176,6 +177,25 @@ func (s *AliSolver) validSecretData(data []byte) bool {
 		}
 	}
 	return true
+}
+
+// resolveChallengeDNSNames returns the FQDN and the zone encompassing the challenge.
+func (s *AliSolver) resolveChallengeDNSNames(ctx context.Context, challenge *acme.ChallengeRequest) (string, string) {
+	zone := challenge.ResolvedZone
+	// If the detected zone looks like a root domain with a trailing dot only,
+	// it is likely incorrect, so try to recover the authoritative zone via AliDNS.
+	if strings.Index(zone, ".") == len(zone)-1 {
+		klog.Warningf("The zone encompassing the FQDN is invalid: %v", zone)
+		resolvedZone, err := resolveZone(ctx, challenge.ResolvedFQDN, alidnsServers, true)
+		if err != nil {
+			klog.Warningf("Failed to resolve FQDN by alidns servers: %s", err)
+		}
+
+		zone = resolvedZone
+		klog.Infof("Discovered zone record %q for fqdn %q", zone, challenge.ResolvedFQDN)
+	}
+
+	return challenge.ResolvedFQDN, zone
 }
 
 // AliDNS is a client for manipulating Aliyun-DNS

--- a/dns.go
+++ b/dns.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"context"
+	"slices"
+
+	"github.com/cert-manager/cert-manager/pkg/issuer/acme/dns/util"
+	"github.com/miekg/dns"
+	"github.com/pkg/errors"
+)
+
+var (
+	// alidnsServers lists the public AliDNS resolvers used to discover the authoritative zone.
+	alidnsServers = []string{"223.5.5.5:53", "223.6.6.6:53"}
+)
+
+// resolveZone resolves the SOA for an FQDN and returns the primary nameserver of the matching zone.
+func resolveZone(ctx context.Context, fqdn string, nameservers []string, recursive bool) (string, error) {
+	in, err := dnsQuery(ctx, fqdn, nameservers, recursive)
+	if err != nil {
+		return "", err
+	}
+
+	// Search both the answer and authority sections because SOA records may be
+	// returned in either place depending on how the resolver responds.
+	for _, ans := range slices.Concat(in.Answer, in.Ns) {
+		if soa, ok := ans.(*dns.SOA); ok {
+			return soa.Hdr.Name, nil
+		}
+	}
+	return "", errors.New("no SOA records found")
+}
+
+// dnsQuery queries the given nameservers for the SOA of an FQDN.
+//
+// This implementation is adapted from
+//   - https://github.com/cert-manager/cert-manager/blob/master/pkg/issuer/acme/dns/util/wait.go
+func dnsQuery(ctx context.Context, fqdn string, nameservers []string, recursive bool) (*dns.Msg, error) {
+	m := new(dns.Msg)
+	m.SetQuestion(fqdn, dns.TypeSOA)
+	m.SetEdns0(4096, false)
+	m.RecursionDesired = recursive
+
+	udp := &dns.Client{Net: "udp", Timeout: util.DNSTimeout}
+	tcp := &dns.Client{Net: "tcp", Timeout: util.DNSTimeout}
+
+	// Will retry the request based on the number of servers (n+1)
+	for _, ns := range nameservers {
+		in, _, err := udp.ExchangeContext(ctx, m, ns)
+		if in != nil && !in.Truncated {
+			return in, err
+		}
+
+		// Try TCP if UDP fails
+		in, _, err = tcp.ExchangeContext(ctx, m, ns)
+		if in != nil && !in.Truncated {
+			return in, err
+		}
+	}
+	return nil, errors.New("failed to resolve FQDN")
+}

--- a/dns_test.go
+++ b/dns_test.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_resolveZone(t *testing.T) {
+	domainName := os.Getenv("WEBHOOK_DOMAIN_NAME")
+	if len(domainName) == 0 {
+		t.Skipf("no domain name set")
+	}
+
+	zone, err := resolveZone(t.Context(), "_acme-challenge.foobar."+domainName+".", alidnsServers, true)
+	if assert.NoError(t, err) {
+		assert.Equal(t, domainName+".", zone)
+	}
+}


### PR DESCRIPTION
This PR adds a fallback mechanism that queries AliDNS public resolvers (223.5.5.5, 223.6.6.6) to discover the correct zone via SOA lookup. related issue https://github.com/wjiec/alidns-webhook/issues/49.